### PR TITLE
fix model slicing corner cases

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1752,7 +1752,17 @@ class _CompoundModelMeta(_ModelMeta):
             except ValueError:
                 raise IndexError(
                     'Compound model {0} does not have a component named '
-                    '{1}'.format(cls.name, index))
+                    '{1}'.format(cls.name, name))
+
+        def check_for_negative_index(index):
+            if index < 0:
+                ind = len(cls.submodel_names) + index
+                if ind < 0:
+                # If still < 0 then this is an invalid index
+                    raise IndexError("Model index {0} out of range.".format(index))
+                else:
+                    return ind
+            return index
 
         if isinstance(index, six.string_types):
             return get_index_from_name(index)
@@ -1766,11 +1776,14 @@ class _CompoundModelMeta(_ModelMeta):
             start = index.start if index.start is not None else 0
             stop = (index.stop
                     if index.stop is not None else len(cls.submodel_names))
+            if isinstance(start, int):
+                start = check_for_negative_index(start)
+            if isinstance(stop, int):
+                stop = check_for_negative_index(stop)
             if isinstance(start, six.string_types):
-                start = cls.submodel_names.index(start)
+                start = get_index_from_name(start)
             if isinstance(stop, six.string_types):
-                stop = cls.submodel_names.index(stop) + 1
-
+                stop = get_index_from_name(stop) + 1
             length = stop - start
 
             if length == 1:
@@ -1782,7 +1795,6 @@ class _CompoundModelMeta(_ModelMeta):
         elif isinstance(index, int):
             if index < 0:
                 index = len(cls.submodel_names) + index
-
             if index < 0 or index >= len(cls.submodel_names):
                 # If still < 0 then this is an invalid index
                 raise IndexError("Model index out of range.")

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -495,3 +495,29 @@ def test_mapping_inverse():
     m = M(12.1, 13.2, 14.3, 15.4)
 
     assert_allclose((0, 1, 2), m.inverse(*m(0, 1, 2)), atol=1e-08)
+
+
+def test_slicing_on_instances_2():
+    """More slicing tests."""
+
+    model_a = Shift(1, name='a')
+    model_b = Shift(2, name='b')
+    model_c = Rotation2D(3, name='c')
+    model_d = Scale(2, name='d')
+    model_e = Scale(3, name='e')
+
+    m = (model_a & model_b) | model_c | (model_d & model_e)
+
+    assert m[1:].submodel_names == ('b', 'c', 'd', 'e')
+    assert m[:].submodel_names == ('a', 'b', 'c', 'd', 'e')
+    assert m['a':].submodel_names == ('a', 'b', 'c', 'd', 'e')
+    assert m['c':'d'].submodel_names == ('c', 'd')
+    assert m[1:2].name == 'b'
+    assert m[2:7].submodel_names == ('c', 'd', 'e')
+    with pytest.raises(IndexError):
+        m['x']
+    with pytest.raises(IndexError):
+        m['a' : 'r']
+    assert m[-4:4].submodel_names == ('b', 'c', 'd')
+    assert m[-4:-2].submodel_names == ('b', 'c')
+


### PR DESCRIPTION
@embray This fixes all failing slicing cases I'm aware of. Added regression tests as well. I'll close the other PR.

I use python 2.x and see compound model evaluation errors. I'm pretty sure this used to work before the rebase. For some reason the failures are different when running the tests and executing a test interactively, I don't know why. This fails interactively (but passes in the tests):

```
A = Const1D.rename('A')
B = Const1D.rename('B')
M = A / B
```

TypeError: unsupported operand type(s) for /: '_ModelMeta' and '_ModelMeta'
